### PR TITLE
Dropped obsolete warning message

### DIFF
--- a/src/main/groovy/de/xm/yangyin/FeatureNameExtension.groovy
+++ b/src/main/groovy/de/xm/yangyin/FeatureNameExtension.groovy
@@ -28,8 +28,6 @@ class FeatureNameExtension implements IGlobalExtension {
   }
 
   void start() {
-    LOG.info("This is an outdate release of yangying and is discontinued. Please use yangyin which is the latest version of the lib")
-    LOG.info("Just replace the package yangying with the package yangyin in your project")
   }
 
   @Override


### PR DESCRIPTION
Dropped obsolete warning message about package replacement
to yangyin cause this has already happend.