### PR TITLE
If there is no existing snapshot create a new one

### DIFF
--- a/src/main/groovy/de/xm/yangyin/FileSnapshots.groovy
+++ b/src/main/groovy/de/xm/yangyin/FileSnapshots.groovy
@@ -40,7 +40,7 @@ class FileSnapshots {
     Path resource = detectResource(comparison)
     def yin = readResource(resource, comparison)
     def yang = current(content, comparison)
-    if (yin != yang && updating()) {
+    if ("" == yin || (yin != yang && updating())) {
       yin = upsertResource(content, resource, comparison)
     }
     assert yin == yang


### PR DESCRIPTION
If no snapshots exists the comparison is running
the first time and a new comparison file should
be created, even if not in update mode.

This PR fixes #57 