### PR TITLE
Update prefered spock version to 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     // Use the latest Groovy version for building this library
     implementation('org.spockframework:spock-core') {
         version {
-            prefer '1.2-groovy-2.5'
+            prefer '1.3-groovy-2.5'
         }
     }
     implementation ('org.slf4j:slf4j-api') {


### PR DESCRIPTION
Yanying can be used with spock 1.2 but does
not compile with JDK 11+. Cause all testing
is done with JDK 11 use spock 1.3 if possible